### PR TITLE
Add HLS output and admin web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ TV operators and broadcasters, internet service providers, hotels, etc.
 
 * Open source version not maintained. Please, check https://cesbo.com/astra/ to get more info.
 * Telegram Community: [EN](https://t.me/cesbo_en) [RU](https://t.me/cesbo_ru)
+
+## HLS Output
+
+Use `http_hls` to segment an incoming MPEG-TS stream and expose the files via
+`http_static`. An example script is available at
+`scripts/examples/http/hls_server.lua`.
+
+## Admin Web UI
+
+Run `scripts/admin.lua` to start a small administration interface. A ready to
+use example is `scripts/examples/admin_server.lua`. The web page is served from
+the `admin` directory.

--- a/admin/app.js
+++ b/admin/app.js
@@ -1,0 +1,13 @@
+function update(){
+  fetch('/api/stats').then(r=>r.json()).then(d=>{
+    document.getElementById('uptime').textContent = d.uptime;
+  });
+}
+function stopServer(){
+  fetch('/api/control?cmd=stop').then(r=>r.json()).then(d=>{
+    alert('Server stopping');
+  });
+}
+setInterval(update,1000);
+update();
+

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Astra Admin</title>
+<script src="app.js"></script>
+</head>
+<body>
+<h1>Astra Admin</h1>
+<p>Uptime: <span id="uptime">0</span> s</p>
+<button onclick="stopServer()">Stop Server</button>
+</body>
+</html>

--- a/modules/http/module.mk
+++ b/modules/http/module.mk
@@ -3,11 +3,13 @@ modules/redirect.c \
 modules/static.c \
 modules/websocket.c \
 modules/upstream.c \
-modules/downstream.c"
+modules/downstream.c \
+modules/hls.c"
 
 MODULES="http_server http_request \
 http_redirect \
 http_static \
 http_websocket \
 http_upstream \
-http_downstream"
+http_downstream \
+http_hls"

--- a/modules/http/modules/hls.c
+++ b/modules/http/modules/hls.c
@@ -1,0 +1,151 @@
+/*
+ * Astra Module: HTTP HLS Output
+ * Generates HLS segments from an upstream MPEG-TS stream
+ */
+#include <astra.h>
+#include "../http.h"
+#include <sys/stat.h>
+
+struct module_data_t
+{
+    MODULE_STREAM_DATA();
+
+    const char *path;
+    int segment_length; // seconds
+    int playlist_size;
+
+    FILE *segment;
+    asc_timer_t *timer;
+
+    char **segments;
+    int seg_index;
+    int seg_total;
+    int seq;
+};
+
+static void write_playlist(module_data_t *mod)
+{
+    char file[512];
+    snprintf(file, sizeof(file), "%s/playlist.m3u8", mod->path);
+    FILE *f = fopen(file, "w");
+    if(!f) return;
+
+    fprintf(f, "#EXTM3U\n#EXT-X-VERSION:3\n");
+    fprintf(f, "#EXT-X-TARGETDURATION:%d\n", mod->segment_length);
+    fprintf(f, "#EXT-X-MEDIA-SEQUENCE:%d\n", mod->seq - mod->seg_total);
+
+    for(int i = 0; i < mod->seg_total; ++i)
+    {
+        int idx = (mod->seg_index + i) % mod->playlist_size;
+        fprintf(f, "#EXTINF:%d,\n%s\n", mod->segment_length, mod->segments[idx]);
+    }
+    fclose(f);
+}
+
+static void rotate_segment(void *arg)
+{
+    module_data_t *mod = (module_data_t *)arg;
+
+    if(mod->segment)
+    {
+        fclose(mod->segment);
+        mod->segment = NULL;
+    }
+
+    char name[64];
+    snprintf(name, sizeof(name), "segment%05d.ts", mod->seq);
+
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s", mod->path, name);
+
+    if(mod->segments[mod->seg_index])
+    {
+        char old[512];
+        snprintf(old, sizeof(old), "%s/%s", mod->path, mod->segments[mod->seg_index]);
+        unlink(old);
+        free(mod->segments[mod->seg_index]);
+    }
+
+    mod->segments[mod->seg_index] = strdup(name);
+    mod->seg_index = (mod->seg_index + 1) % mod->playlist_size;
+    if(mod->seg_total < mod->playlist_size)
+        mod->seg_total++;
+
+    mod->segment = fopen(path, "wb");
+    mod->seq++;
+
+    write_playlist(mod);
+}
+
+static void on_ts(module_data_t *mod, const uint8_t *ts)
+{
+    if(mod->segment)
+        fwrite(ts, TS_PACKET_SIZE, 1, mod->segment);
+}
+
+static void module_init(module_data_t *mod)
+{
+    mod->segment_length = 10;
+    mod->playlist_size = 5;
+    mod->path = NULL;
+
+    module_option_number("segment", &mod->segment_length);
+    module_option_number("playlist", &mod->playlist_size);
+    module_option_string("path", &mod->path, NULL);
+
+    lua_getfield(lua, MODULE_OPTIONS_IDX, "upstream");
+    module_stream_t *upstream = NULL;
+    if(lua_islightuserdata(lua, -1))
+        upstream = (module_stream_t *)lua_touserdata(lua, -1);
+    lua_pop(lua, 1);
+
+    asc_assert(mod->path != NULL, "[http_hls] option 'path' is required");
+    asc_assert(upstream != NULL, "[http_hls] option 'upstream' is required");
+
+    mkdir(mod->path, 0755);
+
+    mod->segments = calloc(mod->playlist_size, sizeof(char*));
+    mod->seg_index = 0;
+    mod->seg_total = 0;
+    mod->seq = 0;
+
+    module_stream_init(mod, on_ts);
+    __module_stream_attach(upstream, &mod->__stream);
+
+    rotate_segment(mod);
+    mod->timer = asc_timer_init(mod->segment_length * 1000, rotate_segment, mod);
+}
+
+static void module_destroy(module_data_t *mod)
+{
+    module_stream_destroy(mod);
+
+    if(mod->timer)
+        asc_timer_destroy(mod->timer);
+
+    if(mod->segment)
+    {
+        fclose(mod->segment);
+        mod->segment = NULL;
+    }
+    for(int i = 0; i < mod->playlist_size; ++i)
+    {
+        if(mod->segments[i])
+        {
+            char path[512];
+            snprintf(path, sizeof(path), "%s/%s", mod->path, mod->segments[i]);
+            unlink(path);
+            free(mod->segments[i]);
+        }
+    }
+    free(mod->segments);
+}
+
+MODULE_STREAM_METHODS()
+MODULE_LUA_METHODS()
+{
+    MODULE_STREAM_METHODS_REF(),
+    { NULL, NULL }
+};
+MODULE_LUA_REGISTER(http_hls)
+

--- a/scripts/admin.lua
+++ b/scripts/admin.lua
@@ -1,0 +1,47 @@
+-- Simple admin web UI
+
+local addr = admin_addr or "0.0.0.0"
+local port = admin_port or 8090
+local root = admin_root or "admin"
+
+local start_time = os.time()
+
+local function api_stats(server, client, request)
+    if not request then return nil end
+    local data = { uptime = os.time() - start_time }
+    server:send(client, {
+        code = 200,
+        headers = {"Content-Type: application/json", "Connection: close"},
+        content = json.encode(data)
+    })
+end
+
+local function api_control(server, client, request)
+    if not request then return nil end
+    local cmd = request.query and request.query.cmd
+    if cmd == "stop" then
+        server:send(client, {
+            code = 200,
+            headers = {"Content-Type: application/json", "Connection: close"},
+            content = json.encode({ result = "stopping" })
+        })
+        astra.exit()
+    else
+        server:send(client, {
+            code = 200,
+            headers = {"Content-Type: application/json", "Connection: close"},
+            content = json.encode({ result = "unknown" })
+        })
+    end
+end
+
+http_server({
+    addr = addr,
+    port = port,
+    route = {
+        { "/api/stats", api_stats },
+        { "/api/control", api_control },
+        { "/*", http_static({ path = root }) }
+    }
+})
+

--- a/scripts/examples/admin_server.lua
+++ b/scripts/examples/admin_server.lua
@@ -1,0 +1,7 @@
+-- Example to start the admin web UI
+
+admin_port = 8090
+admin_root = "admin"
+
+dofile('scripts/admin.lua')
+

--- a/scripts/examples/http/hls_server.lua
+++ b/scripts/examples/http/hls_server.lua
@@ -1,0 +1,19 @@
+-- Example HTTP HLS server
+
+local input = udp_input({ addr = "239.0.0.1", port = 1234 })
+
+http_hls({
+    upstream = input:stream(),
+    path = "./hls",
+    segment = 5,
+    playlist = 5
+})
+
+http_server({
+    addr = "0.0.0.0",
+    port = 8080,
+    route = {
+        { "/hls/*", http_static({ path = "./hls" }) }
+    }
+})
+


### PR DESCRIPTION
## Summary
- implement new `http_hls` module for creating HLS segments
- expose admin web UI served from `admin` directory
- add sample scripts for HLS streaming and admin server
- document both features in `README.md`

## Testing
- `./configure.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ea474b3588321b81750610bfea2d2